### PR TITLE
feat: video-maker enhancements (researcher, model, web-ui)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,7 @@ DEEPSEEK_THINKING=disabled
 # Web UI / LangGraph
 DEEPAGENTS_VIDEO_MAKER_NATIVE=true
 ORCHESTRATOR_SKILLS_ROOT=
+
+# Web search (enables real websearch for researcher subagent)
+# Get your key at https://app.tavily.com
+TAVILY_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test-results/
 .langgraph_api/
 .langgraph-dev.*
 uv.lock
+.claude/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+public-hoist-pattern[]=next

--- a/docs/design/2026-04-25-customizable-workflow-architecture.md
+++ b/docs/design/2026-04-25-customizable-workflow-architecture.md
@@ -1,0 +1,355 @@
+# 可定制化 Workflow 架构设计
+
+日期：2026-04-25  
+状态：draft  
+目标：在 DeepAgents-native Python sidecar 的基础上，引入三层分离设计，使新 workflow（如 podcast-maker、blog-writer）可在不改动 runtime 代码的情况下通过声明式配置实现。
+
+## 1. 问题与动机
+
+`2026-04-25-deepagents-native-video-maker-implementation.md` 的 Phase 1-8 计划把 milestone 序列、subagent contract、ratify 规则、artifact gate 全部硬编在 Python 里（`controller.py / tools.py / prompts/`）。
+
+这与现有 `.claude/skills/video-maker/` SKILL 版本相比反而是退步：
+
+| 维度 | SKILL 版本（当前） | Native 计划（原版） |
+|------|------------------|-------------------|
+| milestone 序列 | `_pipeline.yaml` 声明式 | `controller.py` 硬编 |
+| subagent prompt | `agents/*.md` 单独文件 | `prompts/subagents/*.md` 但与 runtime 强耦合 |
+| ratify 规则 | `ratify/*.md` 单独文件 | `tools.py / ratify.py` 硬编 |
+| 新增 workflow | 新建 skill 目录 | 需改 Python 代码 |
+
+**核心要求**：把 workflow definition（数据）和 workflow runtime（通用 Python）解耦，继承 SKILL 版本已有的声明式模式。
+
+## 2. 三层架构
+
+```text
+┌─────────────────────────────────────────────┐
+│  Layer 1: Workflow Definition Layer          │
+│  (per-workflow, data + markdown)             │
+│  workflows/<name>/pipeline.yaml             │
+│  workflows/<name>/milestones/*.md           │
+│  workflows/<name>/agents/*.md              │
+│  workflows/<name>/ratify/*.yaml            │
+│  workflows/<name>/params.py  (可选)        │
+├─────────────────────────────────────────────┤
+│  Layer 2: Workflow Runtime Layer             │
+│  (通用 Python，所有 workflow 共用)           │
+│  src/deepagents_video_maker/controller.py   │
+│  src/deepagents_video_maker/tools.py        │
+│  src/deepagents_video_maker/subagent_factory│
+│  src/deepagents_video_maker/ratify_engine   │
+├─────────────────────────────────────────────┤
+│  Layer 3: Plugin Hook Layer                  │
+│  (可选 Python，escape hatch)                │
+│  workflows/<name>/hooks/params_resolver.py  │
+│  workflows/<name>/hooks/custom_tools.py     │
+│  workflows/<name>/hooks/ratify_callbacks.py │
+└─────────────────────────────────────────────┘
+```
+
+## 3. Layer 1：Workflow Definition Layer
+
+### 3.1 目录结构
+
+```text
+workflows/
+└── video-maker/
+    ├── pipeline.yaml           # milestone 序列 + 转移规则
+    ├── milestones/
+    │   ├── research.md         # milestone-level prompt（注入 producer）
+    │   ├── script.md
+    │   ├── assets.md
+    │   └── assembly.md
+    ├── agents/
+    │   ├── researcher.md       # subagent prompt + contract（YAML frontmatter）
+    │   ├── scriptwriter.md
+    │   ├── evaluator.md
+    │   ├── reviewer.md
+    │   ├── editor.md
+    │   ├── scene-batch-generator.md
+    │   └── scene-patch-generator.md
+    ├── ratify/
+    │   ├── research.yaml       # gate 规则（schema 声明 + callback ref）
+    │   ├── script.yaml
+    │   ├── assets.yaml
+    │   └── assembly.yaml
+    └── params.py               # 参数派生（可选 escape hatch）
+```
+
+### 3.2 `pipeline.yaml` 格式
+
+```yaml
+workflow_id: video-maker
+version: "1.0"
+
+params_resolver: params.py          # 可选，指向 Layer 3 hook
+
+milestones:
+  - id: research
+    subagent: researcher
+    outputs:
+      - kind: research_md
+        path: "research.md"
+    ratify: ratify/research.yaml
+    retry:
+      max_retries: 2
+      strategy: retry_with_feedback
+    hitl: none
+
+  - id: script
+    depends_on: [research]
+    subagent: scriptwriter
+    outputs:
+      - kind: script_md
+        path: "script.md"
+      - kind: manifest_json
+        path: "manifest.json"
+    ratify: ratify/script.yaml
+    retry:
+      max_retries: 2
+      strategy: retry_with_feedback
+    hitl: none
+
+  - id: assets
+    depends_on: [script]
+    subagent: scene-batch-generator
+    outputs:
+      - kind: scene_tsx
+        path: "generated/scene-*.tsx"
+        pattern: glob
+    ratify: ratify/assets.yaml
+    retry:
+      max_retries: 3
+      strategy: scene_patch
+      patch_subagent: scene-patch-generator
+    hitl:
+      trigger: per_scene_preview
+      approval_mode: batch
+
+  - id: assembly
+    depends_on: [assets]
+    subagent: null                  # 纯 CLI，无 LLM subagent
+    cli_tool: run_assembly
+    outputs:
+      - kind: final_video
+        path: "final/video.mp4"
+    ratify: ratify/assembly.yaml
+    hitl: none
+```
+
+### 3.3 `agents/*.md` frontmatter contract
+
+每个 agent markdown 文件以 YAML frontmatter 声明 input/output contract，prompt 正文作为 subagent system prompt 模板：
+
+```markdown
+---
+agent_id: researcher
+input_schema:
+  topic: string
+  source: string
+  local_file: string?
+  excalidraw_file: string?
+  output_path: string
+  required_sections: list[string]
+  min_chars: int
+  visual_strategy: enum[image_heavy, image_light, image_none]
+
+output_contract:
+  research_path: string
+  summary: string
+  section_count: int
+  source_count: int
+  visual_strategy: string
+  blocking_issues: list[string]
+
+artifact_gate:
+  - check: file_exists
+    path: "{{research_path}}"
+  - check: min_size
+    path: "{{research_path}}"
+    bytes: 800
+  - check: heading_count
+    path: "{{research_path}}"
+    pattern: "^## "
+    min: 3
+---
+
+你是一个专业的视频调研专家...（prompt 正文）
+```
+
+### 3.4 `ratify/*.yaml` 格式
+
+```yaml
+ratify_id: research
+checks:
+  - name: file_exists
+    type: artifact_exists
+    path: "research.md"
+
+  - name: min_size
+    type: file_size
+    path: "research.md"
+    min_bytes: 800
+
+  - name: heading_structure
+    type: regex_count
+    path: "research.md"
+    pattern: "^## "
+    min: 3
+
+  - name: no_placeholder
+    type: regex_not_match
+    path: "research.md"
+    pattern: "\\[TODO\\]|\\[PLACEHOLDER\\]"
+
+# 可选：指向 Layer 3 callback
+custom_callback: hooks/ratify_callbacks.py::check_research_sources
+```
+
+## 4. Layer 2：Workflow Runtime Layer
+
+Runtime 层不写任何 workflow 特定逻辑，全部从 `pipeline.yaml` + `agents/*.md` + `ratify/*.yaml` 读取配置执行。
+
+### 4.1 核心模块职责
+
+```text
+src/deepagents_video_maker/
+├── workflow_loader.py      # 加载 workflows/<name>/ 目录，解析 pipeline.yaml + agents + ratify
+├── controller.py           # 通用 protocol executor（从 pipeline.yaml 读状态机）
+├── subagent_factory.py     # 从 agents/*.md frontmatter + prompt 生成 DeepAgents subagent
+├── ratify_engine.py        # 从 ratify/*.yaml 执行 gate checks（dispatch 到内置 check 类型）
+├── tools.py                # 通用 typed tools（init_session/save_state/collect_artifacts/...）
+├── models.py               # Pydantic models（WorkflowDefinition, MilestoneState, RatifyResult...）
+└── plugin_registry.py      # 注册/发现 Layer 3 hook
+```
+
+### 4.2 `controller.py` 核心逻辑
+
+```python
+class WorkflowController:
+    def __init__(self, workflow_def: WorkflowDefinition, state: VideoMakerState):
+        self.workflow = workflow_def
+        self.state = state
+
+    def next_milestone(self) -> MilestoneDefinition | None:
+        """从 pipeline.yaml 的 depends_on 图计算下一个可执行 milestone。"""
+        ...
+
+    def execute_milestone(self, milestone: MilestoneDefinition) -> MilestoneResult:
+        """通用执行：dispatch subagent / cli_tool → ratify → update state。"""
+        ...
+```
+
+`controller.py` 不知道"research"、"script"、"assets"这些名字 — 这些都在 `pipeline.yaml` 里。
+
+### 4.3 `subagent_factory.py`
+
+```python
+def create_subagent(agent_def: AgentDefinition, inputs: dict) -> SubagentTask:
+    """
+    从 agents/*.md 的 frontmatter contract + prompt 正文
+    + inputs 渲染出 DeepAgents subagent task。
+    """
+    prompt = render_template(agent_def.prompt_template, inputs)
+    return SubagentTask(
+        subagent_type=agent_def.agent_id,
+        system_prompt=prompt,
+        input_schema=agent_def.input_schema,
+        output_contract=agent_def.output_contract,
+    )
+```
+
+### 4.4 `ratify_engine.py`
+
+```python
+class RatifyEngine:
+    # 内置 check 类型注册表
+    _built_in_checks: dict[str, CheckFn] = {
+        "artifact_exists": check_file_exists,
+        "file_size": check_file_size,
+        "regex_count": check_regex_count,
+        "json_schema": check_json_schema,
+        ...
+    }
+
+    def ratify(self, ratify_def: RatifyDefinition, context: dict) -> RatifyResult:
+        results = [self._run_check(c, context) for c in ratify_def.checks]
+        if ratify_def.custom_callback:
+            results.append(self._run_callback(ratify_def.custom_callback, context))
+        return RatifyResult.from_checks(results)
+```
+
+## 5. Layer 3：Plugin Hook Layer
+
+在不改动 runtime 的情况下，为特定 workflow 注入自定义逻辑。
+
+```text
+workflows/video-maker/hooks/
+├── params_resolver.py      # 自定义参数推导（replace 或 extend 默认逻辑）
+├── custom_tools.py         # 注册额外 typed tool
+└── ratify_callbacks.py     # ratify 自定义 callback（复杂 Python 逻辑）
+```
+
+### 5.1 注册方式
+
+通过 workflow `pipeline.yaml` 的 `params_resolver` 字段 + ratify `custom_callback` 字段按需引入，不改 runtime 模块，不用 entry-point。
+
+### 5.2 使用约束
+
+- Hook 必须无副作用（不直接写 state）
+- Hook 输出须符合明确 return type（TypedDict / Pydantic）
+- Hook 失败视为 ratify fail，进入 retry/blocked，不 silently 跳过
+
+## 6. 新 workflow 如何接入
+
+以 `podcast-maker` 为例，只需：
+
+```text
+workflows/podcast-maker/
+├── pipeline.yaml           # 定义 research→transcript→audio→assembly 序列
+├── agents/
+│   ├── researcher.md
+│   └── transcript-writer.md
+├── ratify/
+│   ├── research.yaml
+│   └── transcript.yaml
+└── params.py               # podcast 专属参数派生（duration/speaker_count...）
+```
+
+runtime 代码零改动，`WorkflowController` 加载 `podcast-maker/pipeline.yaml` 就能运行。
+
+## 7. 与原 Native 计划的映射
+
+| 原 Native 计划 | 三层架构映射 |
+|--------------|------------|
+| `prompts/producer.md` | runtime `controller.py` + 各 workflow `pipeline.yaml` 注入的 milestone prompts |
+| `prompts/subagents/*.md` | `workflows/<name>/agents/*.md` (Layer 1) |
+| `ratify.py ratify_research()` | `workflows/<name>/ratify/research.yaml` + `ratify_engine.py` dispatch |
+| `tools.py` typed tools | `tools.py` 保留但不写 workflow 特定逻辑 |
+| `models.py` | 保留，新增 `WorkflowDefinition / AgentDefinition / RatifyDefinition` |
+
+原计划的 Phase 1-8 步骤保持不变，只需在实现时把 workflow 特定内容导向 Layer 1 文件而不是 Python 硬编。
+
+## 8. 分步实现建议
+
+**Phase 1（保守版，第一步）**：
+只外置 milestone 序列和 subagent 名字到 `pipeline.yaml`，ratify 和 agent contract 仍可先用 Python，等跑通 video-maker 后再声明化。
+
+**Phase 2**：
+`agents/*.md` frontmatter contract 上线，`subagent_factory.py` 从 markdown 读 schema 而不是硬编。
+
+**Phase 3**：
+`ratify/*.yaml` 上线，`ratify_engine.py` dispatch 内置 check 类型，减少 `ratify.py` 里的 if-else。
+
+**第二个 workflow 落地时**：
+Layer 3 plugin hook 按需引入，不提前设计。
+
+## 9. 主要 Tradeoff
+
+| 优点 | 风险 |
+|------|------|
+| 新 workflow 不改 Python | schema 设计不当会导致频繁 escape 到 Python |
+| 声明式配置可 diff/review | YAML 越复杂越难调试 |
+| runtime 可独立测试 | 初期工程投入比直接硬编高 |
+| 继承现有 SKILL 版本的可维护性 | |
+
+**原则**：三层架构不是一次全上，从 `pipeline.yaml` milestone 序列开始，逐步声明化。有第二个 workflow 需求之前，不要过度设计 plugin 系统。

--- a/docs/design/deepagents-skill-video-maker-rosy-balloon.md
+++ b/docs/design/deepagents-skill-video-maker-rosy-balloon.md
@@ -1,0 +1,370 @@
+# DeepAgents-Native Video-Maker 抽离为独立项目
+
+## Context
+
+当前 `e:/workspace/orchestrator_skills` 仓库混杂了多套 video-maker 实现：
+- `src/agent/` + `src/agent-ui/`：DAG scheduler + Fastify/Vite Web app
+- `.claude/skills/video-maker/`：Claude Code 会话内的 Skill 编排（Producer-Crew + 业务知识 md；其下的 pipeline-cli / Remotion template 本次不迁，后续独立项目化）
+- `src/deepagents_video_maker/`（**目标方案**）：DeepAgents-native Producer，已实现 research/script milestone，复用 `.claude/skills/video-maker/` 的业务知识 md 作 progressive disclosure
+- `deepagent-video-maker-ui/`：Next.js + LangGraph Dev UI
+
+用户的目标：只保留 **deepagents（Python sidecar）+ skill（业务知识 md）+ Web UI** 这一条链路，抽到一个独立 repo，让后续演进不再被旁路代码干扰。`pipeline-cli` 和 `remotion-template` 后续作为独立 project / 外部依赖处理，本次不迁入新仓库。
+
+本次只做"剥离打包"，不补 assets/assembly milestone，也不重构现有代码。
+
+---
+
+## 用户已确认决策
+
+1. **位置**：同级新目录 `e:/workspace/deepagents-video-maker`，独立 git repo
+2. **范围**：3 大块全迁（Python 编排层 + Skill 业务知识 md + Next.js Web UI）；不迁 `pipeline-cli` / `remotion-template`
+3. **完成度**：只迁现状，研究/脚本 milestone 跑通即可，assets/assembly 留待后续
+4. **Skill 复用**：直接拷贝为副本，与原仓库独立演进
+5. **迁移基准**：必须包含 2026-04-27 最新 pipeline fixes（`goal.yaml` fallback、YAML Windows path escaping、LangSmith smoke tracing、`vm_ratify_script` fallback、对应 tests）
+6. **命令约定**：Python 命令统一使用 `uv run ...`；不使用裸 `pytest` / `python`
+7. **旧 skill 附属目录**：`assets/`、`reflexion/` 与 `references/`、`scripts/`、`templates/` 一起 copy
+8. **路径回归**：必须加 grep/测试，确保代码与配置不再引用 `.claude/skills/video-maker`
+9. **渲染工具链边界**：`pipeline-cli` 与 `remotion-template` 不进入新仓库；后续单独建 repo 或以 package/dependency 方式接入
+
+---
+
+## Task 0: Freeze source snapshot（必须先做）
+
+当前 `orchestrator_skills` worktree 包含本迁移必须带走的最新修复。执行迁移前先二选一：
+
+1. **推荐**：提交当前 deepagents-video-maker 相关 fixes，再从该 commit 迁移。
+2. **可接受**：明确从当前 dirty working tree 迁移，并在新仓库验证同等行为。
+
+必须包含这些文件中的最新变更：
+
+- `src/deepagents_video_maker/langchain_tools.py`
+  - `vm_build_researcher_task` / `vm_ratify_research` / `vm_build_scriptwriter_task` / `vm_ratify_script` 支持无 `topic/source/...` 时从 `output_dir/goal.yaml` fallback。
+- `src/deepagents_video_maker/state_store.py`
+  - `load_goal_yaml()`
+  - `_scalar()` 正确 escape Windows backslash，保证 PyYAML 可 parse。
+- `scripts/smoke_skills_research_script.py`
+  - 加载 `.env`
+  - `LANGSMITH_*` / `LANGCHAIN_*` 覆盖当前进程环境
+  - `@traceable(name="skills_research_script_smoke")`
+- `tests/deepagents_video_maker/test_langchain_tools.py`
+  - 覆盖 build/ratify tools 从 `goal.yaml` fallback。
+
+迁移前在原仓库记录：
+
+```powershell
+git rev-parse HEAD
+git status --short
+uv run pytest tests/deepagents_video_maker -q
+```
+
+当前已知基准：`uv run pytest tests/deepagents_video_maker -q` 应为 `63 passed`（或更多，但不能有失败）。
+
+## 新仓库目录结构
+
+```
+deepagents-video-maker/
+├── pyproject.toml
+├── package.json                # root scripts（主要代理 web-ui + Python 命令）
+├── pnpm-workspace.yaml         # 仅包含 web-ui；预留未来外部包接入
+├── .gitignore
+├── .env.example
+├── README.md
+├── AGENTS.md                   # 精简版（~30 行），描述 Quick Start + 架构骨架
+├── CLAUDE.md                   # 精简版，给 Claude Code 用
+├── src/
+│   └── deepagents_video_maker/ # Python 包，import path 不变
+│       ├── __init__.py
+│       ├── agent.py            # 主工厂 create_video_maker_agent
+│       ├── prompts/            # producer.md + subagents/*.md
+│       └── …                   # models, flows, tools, ratify, state_store…
+├── tests/
+│   └── deepagents_video_maker/ # test_*.py + conftest.py（以迁移基准为准）
+├── scripts/
+│   ├── deepagents_video_maker.py        # 改写成 thin runner（见下）
+│   └── smoke_skills_research_script.py  # deterministic typed-tool smoke + LangSmith trace
+├── .deepagents/
+│   └── skills/
+│       ├── video-researcher/SKILL.md       # progressive disclosure wrapper
+│       └── video-scriptwriter/SKILL.md
+├── skills/
+│   └── video-maker/            # 原 .claude/skills/video-maker/ 业务知识（去掉 .claude/ 前缀）
+│       ├── SKILL.md
+│       ├── milestones/         # _pipeline.yaml + research.md + script.md (+ assets.md/assembly.md 留作未来)
+│       ├── agents/             # researcher.md, scriptwriter.md, evaluator.md, reviewer.md, scene-batch-generator.md
+│       └── ratify/             # research-rules.md, script-rules.md (+ 未来 assets/assembly)
+└── web-ui/                     # workspace pkg "deepagent-video-maker-ui"
+    ├── package.json
+    ├── langgraph.json          # graphs.video-maker = ./agent/agent.py:agent
+    ├── agent/agent.py          # LangGraph 胶水
+    └── src/                    # Next.js app
+```
+
+**为什么这样分**：
+- `.deepagents/skills/` 保留点前缀，因为 `agent.py:_SUBAGENT_SKILL_DIRS` 里硬编码这条相对路径，迁移后无需改代码
+- `skills/video-maker/` 去掉 `.claude/` 前缀，新仓库不再是 Claude Code 项目根，不需要那层命名空间
+- 本次只保留一个 pnpm workspace package：`web-ui/`。原仓库 `.claude/skills/video-maker/` 下的 `video-pipeline-cli/` 与 `remotion-template/` 不拷入新仓库；未来单独项目化后再通过 package/dependency/API 接入。
+
+---
+
+## 文件迁移清单
+
+约定：`copy` = 字节级拷贝；`rewrite` = 拷贝后修补；`skip` = 不迁。
+
+### Python 编排层
+| 源 | 目标 | 操作 |
+|---|---|---|
+| `src/deepagents_video_maker/**`（含 `prompts/`） | `src/deepagents_video_maker/**` | rewrite（仅 `prompts/producer.md` 第 9 行 `.claude/skills/video-maker/` → `skills/video-maker/`） |
+| `tests/deepagents_video_maker/**` | `tests/deepagents_video_maker/**` | rewrite（`test_skill_files.py` 见 §路径调整） |
+| `.deepagents/skills/video-researcher/SKILL.md` | `.deepagents/skills/video-researcher/SKILL.md` | rewrite（`/.claude/skills/video-maker/` → `/skills/video-maker/`） |
+| `.deepagents/skills/video-scriptwriter/SKILL.md` | `.deepagents/skills/video-scriptwriter/SKILL.md` | rewrite（同上） |
+| `scripts/deepagents_video_maker.py` | `scripts/deepagents_video_maker.py` | rewrite（去掉 path-coupled 死路径，见 §scripts 处理） |
+| `scripts/smoke_skills_research_script.py` | `scripts/smoke_skills_research_script.py` | copy（必须包含 LangSmith traceable 最新版本） |
+| `scripts/_smoke_verbose.py`、`_smoke_verbose2.py`、`_check_run.py`、`_thread_state.py`、`smoke_native.py`、`smoke_final.py` | — | skip（实验残留） |
+| `pyproject.toml` | `pyproject.toml` | rewrite（rename project + 补 `langchain-openai`） |
+| `.env.example` | `.env.example` | rewrite（只保留新仓库需要的 LangSmith/model/provider/native env，见 §`.env.example`） |
+
+### Skill 业务知识（活跃部分）
+| 源 | 目标 | 操作 |
+|---|---|---|
+| `.claude/skills/video-maker/SKILL.md` | `skills/video-maker/SKILL.md` | rewrite（grep `.claude/skills` 字面量并替换为 `skills/`） |
+| `.claude/skills/video-maker/milestones/{_pipeline.yaml, research.md, script.md, assets.md, assembly.md}` | `skills/video-maker/milestones/…` | rewrite（同样 grep + 替换） |
+| `.claude/skills/video-maker/agents/{researcher, scriptwriter, evaluator, reviewer, scene-batch-generator}.md` | `skills/video-maker/agents/…` | rewrite |
+| `.claude/skills/video-maker/agents/{editor, scene-patch-generator}.md` | — | skip（已废弃） |
+| `.claude/skills/video-maker/ratify/{research-rules, script-rules, assets-rules, assembly-rules}.md` | `skills/video-maker/ratify/…` | copy |
+| `.claude/skills/video-maker/{assets, reflexion, references, scripts, templates}/**`（如有） | `skills/video-maker/…` | copy |
+| `.claude/skills/video-maker/{video-pipeline-cli, remotion-template}/**` | — | skip（后续独立 project，不进入本 repo） |
+
+### 渲染工具链（本次不迁）
+| 源 | 目标 | 操作 |
+|---|---|---|
+| `.claude/skills/video-maker/video-pipeline-cli/**` | — | skip（未来独立 repo） |
+| `.claude/skills/video-maker/remotion-template/**` | — | skip（未来独立 repo） |
+
+### Next.js Web UI
+| 源 | 目标 | 操作 |
+|---|---|---|
+| `deepagent-video-maker-ui/{package.json, next.config.ts, src/, public/, tailwind.config.*, postcss.config.*, tsconfig.json, eslint.config.*, agent/agent.py, langgraph.json}` | `web-ui/…` | rewrite（`agent/agent.py` 见 §路径调整；`package.json` 改 packageManager 为 pnpm） |
+| `deepagent-video-maker-ui/{node_modules, .next, .turbo, out, yarn.lock}` | — | skip |
+
+### 顶层文档
+| 源 | 目标 | 操作 |
+|---|---|---|
+| 现有 `AGENTS.md`、`CLAUDE.md`、`README.md` | — | skip；写新版（顶层 < 80 行，描述新仓库定位） |
+| `docs/plans/2026-04-25-deepagents-*.md`、`2026-04-26-deepagents-skills-research-script.md`、`research.md` | `docs/design/` | copy（保留设计源头供未来对照） |
+
+### 不迁的范围（确认）
+`src/agent/`、`src/agent-ui/`、`specs/`、`tasks/`、`output/`、`logs/`、`playwright*`、所有 `.claude/{agents,commands,hooks,plugins,settings*}` 配置、`.gstack/`、`.baoyu-skills/`、`.superpowers/`、`videomaker-playground.html`、`debug_sign_in.png`、`SPEC_RESEARCH_REPORT_*.md`、`TODOS.md`、`output.mp3`。
+
+---
+
+## 路径与代码调整
+
+### 1. `tests/deepagents_video_maker/test_skill_files.py`
+- 第 24 行 `if ".claude/skills" in line:` 改为 `if "skills/video-maker" in line:`
+- 第 25 行的断言信息一并更新（`/.claude/skills` 字面量 → `/skills/video-maker`）
+- 追加断言：wrapper 中任何业务知识引用必须使用 `/skills/video-maker/...`
+- 追加断言：代码与配置中不得出现 `.claude/skills/video-maker`（`docs/design/` 历史文档豁免）
+
+### 2. `src/deepagents_video_maker/prompts/producer.md`
+- 第 9 行 `不读取 .claude/skills/video-maker/ 业务 prompt` → `不读取 skills/video-maker/ 业务 prompt`
+
+### 3. `.deepagents/skills/video-{researcher,scriptwriter}/SKILL.md`
+- 文件内三处 `/.claude/skills/video-maker/` 字面量 → `/skills/video-maker/`
+
+### 4. `scripts/deepagents_video_maker.py`（path-coupling 修复）
+当前脚本引用两条**不存在的路径**：
+- `SKILL_PATH = .deepagents/skills/video-maker/SKILL.md`（不存在）
+- `AGENTS_DIR = .deepagents/agents`（不存在）
+
+并且 `check_files()` 还写死了 `.claude/skills/video-maker/SKILL.md` 与 `milestones/_pipeline.yaml`。
+
+**改写策略**（最小修补，不重构）：
+- 删除 `SKILL_PATH`、`AGENTS_DIR`、`SUBAGENT_NAMES`、`load_system_prompt()`、`load_subagents()`、`check_files()` 这一套早期实现
+- `build_agent()` 内部改为调用 `from deepagents_video_maker.agent import create_video_maker_agent` + `create_video_maker_agent(resolve_model(model), project_root=PROJECT_ROOT, interrupt=interrupt, checkpointer=None)`
+- 默认不要使用 `checkpointer=True` 或 `MemorySaver()`；已实测 root graph 使用 `checkpointer=True` 会报 `RuntimeError: checkpointer=True cannot be used for root graphs.`
+- 保留：`load_env_files`, `resolve_model`, `to_virtual_path`, `patch_deepagents_path_validation`, `execute_pwsh`, `project_glob`, `main()` CLI 入口
+- `--check` flag 改为简单读 `src/deepagents_video_maker/__init__.py` 是否能 import + `skills/video-maker/SKILL.md` 是否存在
+- `main()` 中真实 invoke 使用：
+  ```python
+  agent = build_agent(args.model, interrupt=args.interrupt, checkpointer=False)
+  result = agent.invoke(
+      {"messages": [{"role": "user", "content": " ".join(args.prompt)}]},
+      config={"configurable": {"thread_id": args.thread_id}, "recursion_limit": 100},
+  )
+  ```
+
+### 5. `web-ui/agent/agent.py`
+- 第 18 行 `PROJECT_ROOT = Path(__file__).resolve().parents[2]` → `parents[2]` 在新布局下指向 repo 根（`web-ui/agent/agent.py` 上两级），仍然正确
+- 第 25 行 `from scripts.deepagents_video_maker import build_agent, load_env_files, resolve_model` 在新布局下仍可解析，因为 `parents[2]` 是 repo 根，`sys.path` 已加 root + `src/`
+- 第 33 行 `DEEPAGENTS_VIDEO_MAKER_NATIVE` 默认改为 `"true"`（`os.environ.get(..., "true")`），让新仓库默认走 native 工厂；legacy `build_agent` 分支保留作为 fallback 调试用
+
+### 6. `web-ui/package.json`
+- `packageManager: "yarn@1.22.22"` → `"pnpm@9.x"`（统一全仓库 pnpm，遵循全局 CLAUDE.md 约定）
+- `agent:dev` 不再依赖隔离 `uvx` 默认环境；改成 root workspace 脚本统一用 `uv run` 启动 LangGraph dev server，避免新仓库 Python 包和 deps 不在 `uvx` 环境中。
+- 如果保留 `uvx` fallback，必须显式加 `--with-editable .. --with langchain-anthropic --with langchain-openai --with PyYAML`。
+
+### 7. `langchain_tools.py` 的 env var
+- 当前用 `ORCHESTRATOR_SKILLS_ROOT`，在 `agent.py:65` 与 `web-ui/agent/agent.py:31` 都设置过。**保留原名**避免触发 14 个测试；新仓库注释里说明这是历史命名，未来可重命名
+
+### 8. `tests/deepagents_video_maker/conftest.py`
+- fixture 用 `Path("test-results") / "deepagents-video-maker-tmp"`，相对 CWD 工作，无需改
+
+### 9. `.env.example`
+不要字节级 copy 混合仓库的 `.env.example`。写新仓库最小版本：
+
+```dotenv
+# LangSmith tracing
+LANGSMITH_TRACING=true
+LANGSMITH_API_KEY=
+LANGSMITH_ENDPOINT=https://api.smith.langchain.com
+LANGSMITH_PROJECT=deepagents-video-maker
+LANGCHAIN_CALLBACKS_BACKGROUND=false
+
+# Model provider
+DEEPAGENTS_MODEL=anthropic:claude-sonnet-4-5-20250929
+ANTHROPIC_API_KEY=
+
+# Optional DeepSeek OpenAI-compatible route
+DEEPSEEK_API_KEY=
+DEEPSEEK_BASE_URL=https://api.deepseek.com
+DEEPSEEK_THINKING=disabled
+
+# Web UI / LangGraph
+DEEPAGENTS_VIDEO_MAKER_NATIVE=true
+ORCHESTRATOR_SKILLS_ROOT=
+```
+
+---
+
+## 配置文件草案
+
+### `pyproject.toml`
+```toml
+[project]
+name = "deepagents-video-maker"
+version = "0.1.0"
+description = "DeepAgents-native video-maker orchestrator"
+requires-python = ">=3.11"
+dependencies = [
+  "deepagents>=0.5.3",
+  "langchain>=0.3.0",
+  "langchain-core>=0.3.0",
+  "langchain-anthropic>=0.3.0",
+  "langchain-openai>=0.3.0",   # 新增：DeepSeek OpenAI-兼容路径
+  "PyYAML>=6.0",
+]
+
+[dependency-groups]
+dev = ["pytest>=8.0.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests/deepagents_video_maker"]
+pythonpath = ["src"]
+addopts = "-q -p no:cacheprovider"
+```
+
+### `package.json`（root）
+```json
+{
+  "name": "deepagents-video-maker",
+  "private": true,
+  "packageManager": "pnpm@9",
+  "scripts": {
+    "ui:dev": "pnpm --filter deepagent-video-maker-ui dev",
+    "agent:dev": "uv run langgraph dev --config web-ui/langgraph.json",
+    "test:py": "uv run pytest tests/deepagents_video_maker"
+  }
+}
+```
+
+### `pnpm-workspace.yaml`
+```yaml
+packages:
+  - web-ui
+```
+
+### `.gitignore`（关键项）
+```
+.venv/
+__pycache__/
+*.egg-info/
+node_modules/
+.next/
+.turbo/
+out/
+dist/
+output/
+test-results/
+.tmp/
+.env
+.env.local
+.DS_Store
+```
+
+### `README.md`（骨架）
+- 一句话定位：**DeepAgents-native video-maker orchestrator，当前可运行链路为 research → script；assets/assembly 后续通过独立渲染工具链接入**
+- Quick Start：`uv sync` → `pnpm install` → `pnpm test:py` → `pnpm agent:dev`
+- 链接到 `docs/design/` 设计文档
+
+---
+
+## 验证 Checklist
+
+新仓库 cherry-pick 完成后逐项确认：
+
+1. `uv sync` 依赖解析成功
+2. `pnpm install` 在 root 成功，`pnpm -r ls` 列出 1 个 workspace 包：`deepagent-video-maker-ui`
+3. `uv run pytest tests/deepagents_video_maker -q` 全绿（当前源仓库基准为 `63 passed`）
+4. `uv run python scripts/deepagents_video_maker.py --check` 输出 OK，无 SystemExit
+5. `uv run python scripts/smoke_skills_research_script.py` 跑通（deterministic typed-tool smoke，并写 LangSmith trace `skills_research_script_smoke`）
+6. `uv run langgraph dev --config web-ui/langgraph.json` 启动 LangGraph dev server（langgraph.json 解析 `./agent/agent.py:agent` 成功，default `DEEPAGENTS_VIDEO_MAKER_NATIVE=true` 走 native 工厂）
+7. 全仓 grep `\.claude/skills` 在代码与配置中零匹配（仅可能在 `docs/design/` 历史文档里出现）
+8. 全仓确认不存在迁入的渲染工具链目录：
+    ```powershell
+    Test-Path pipeline-cli
+    Test-Path remotion-template
+    Test-Path skills/video-maker/video-pipeline-cli
+    Test-Path skills/video-maker/remotion-template
+    ```
+    Expected: 全部为 `False`。
+9. 跑一次真实 DeepAgents invoke（非 deterministic smoke）：
+    ```powershell
+    uv run python scripts/deepagents_video_maker.py --thread-id migration-real-smoke "请生成介绍 video-maker skill 的视频。source=local-file local_file=/docs/design/ARCHITECTURE-VIDEO-MAKER.md duration=1-3min style=professional"
+    ```
+    Expected: research + script milestones completed；LangSmith project 中出现 `video-maker-producer` success trace。
+
+---
+
+## 关键文件清单（实施时直接对照）
+
+需要修改路径或代码的文件：
+- `e:/workspace/orchestrator_skills/scripts/deepagents_video_maker.py`（删 SKILL_PATH/AGENTS_DIR，build_agent 改调 create_video_maker_agent）
+- `e:/workspace/orchestrator_skills/src/deepagents_video_maker/prompts/producer.md`（line 9 字面量替换）
+- `e:/workspace/orchestrator_skills/.deepagents/skills/video-researcher/SKILL.md`（3 处字面量替换）
+- `e:/workspace/orchestrator_skills/.deepagents/skills/video-scriptwriter/SKILL.md`（同上）
+- `e:/workspace/orchestrator_skills/tests/deepagents_video_maker/test_skill_files.py`（line 24-25 路径子串）
+- `e:/workspace/orchestrator_skills/deepagent-video-maker-ui/agent/agent.py`（NATIVE 默认 true）
+- `e:/workspace/orchestrator_skills/deepagent-video-maker-ui/package.json`（packageManager → pnpm）
+- `e:/workspace/orchestrator_skills/.claude/skills/video-maker/{SKILL.md, milestones/*.md, agents/*.md}`（grep `.claude/skills` 字面量做批量替换）
+- `e:/workspace/orchestrator_skills/src/deepagents_video_maker/langchain_tools.py`（必须包含最新 `goal.yaml` fallback）
+- `e:/workspace/orchestrator_skills/src/deepagents_video_maker/state_store.py`（必须包含 `load_goal_yaml` 和 Windows path escaping）
+- `e:/workspace/orchestrator_skills/scripts/smoke_skills_research_script.py`（必须包含 LangSmith traceable）
+
+需要新建的文件：
+- `e:/workspace/deepagents-video-maker/{pyproject.toml, package.json, pnpm-workspace.yaml, .gitignore, .env.example, README.md, AGENTS.md, CLAUDE.md}`
+
+---
+
+## 风险与开放问题
+
+1. **`langchain-openai` 是必需依赖**：DeepSeek 路径在 `scripts/deepagents_video_maker.py:resolve_model` 用 `from langchain_openai import ChatOpenAI`。必须加进 dependencies，否则 `.env` 里 `DEEPAGENTS_MODEL=deepseek:*` 时会启动失败。
+
+2. **新仓库是不是要再写一份"会被 Claude Code 看到"的 `.claude/skills/video-maker/`**：当前方案是只放到 `skills/video-maker/`，作为 deepagents subagent skill 的目标。如果你也想在新仓库里继续用 Claude Code 会话直接跑老 Skill 编排（即不通过 deepagents 入口），就要再做一份 `.claude/skills/video-maker/` 软拷或符号链接。**默认假设：不需要**——deepagents 入口是新仓库唯一的执行路径。
+
+3. **`docs/design/` 要带过去**：copy 设计源头，至少包含 `2026-04-25-deepagents-native-video-maker-implementation.md`、`2026-04-26-deepagents-skills-research-script.md`、`research.md`；其他重型历史文档可按需补充。
+
+4. **`web-ui/package.json` 切到 pnpm 后，lockfile 重生成**：原 yarn.lock 不带过去，`pnpm install` 时会重新解析 Web UI 依赖，可能出现 minor 版本漂移（特别是 React/Next/Tailwind 的 transitive deps）。建议迁移后立即跑 `pnpm --filter deepagent-video-maker-ui dev` 验证渲染正常。
+
+5. **后续 milestone（assets/assembly）的预留**：`skills/video-maker/{milestones,ratify}` 已经包含 assets/assembly 的 md（业务侧已就绪），但 Python 这边 `langchain_tools.py` 还没有 `vm_start_assets`、`vm_ratify_assets`、`vm_start_assembly` 等 typed tools；并且渲染执行依赖未来独立的 `pipeline-cli` / `remotion-template` 项目。后续 milestone 是另一个独立 plan，本次不动。
+
+6. **渲染工具链外部化接口未定义**：本计划只确保 research/script pipeline 可运行；未来接入 assets/assembly 时，需要新 plan 明确 `pipeline-cli` 和 `remotion-template` 以 npm package、git submodule、local path dependency、CLI binary 还是 service API 形式接入。

--- a/docs/design/langchain-doc-research-video-maker-skil-zippy-owl.md
+++ b/docs/design/langchain-doc-research-video-maker-skil-zippy-owl.md
@@ -1,0 +1,295 @@
+# Plan: deepagent-video-maker-ui 全栈式 UI 优化
+
+## Context
+
+`E:\workspace\orchestrator_skills\deepagent-video-maker-ui` 是 langchain-ai/deep-agents-ui 的 fork，承担 video-maker DeepAgent (LangGraph) 的前端。当前 UI 是通用的 chat shell，但 video-maker 这个 producer workflow 的实际场景有几个特殊需求未被满足：
+
+- 工作流分 4 个里程碑（research → script → assets → assembly），每个里程碑 5–30 分钟，需要可见的进度反馈
+- 大量 subagent 派发链（researcher / scriptwriter / scene-batch-generator / evaluator 等），用户需要看清父子关系
+- 关键产物是多媒体（mp4 视频 / png 图片 / json manifest），目前 FileViewDialog 只能预览文本/markdown
+- assets 里程碑有 manual audio pause 中断，审批 UI 仍是 raw JSON 编辑
+
+通用的 UI 问题：硬编码颜色（`#2F6868`、`#3F3F46`、`#70707B`）破坏深青色主题 token 体系；多处 dark mode 缺补丁（`STATUS_COLORS` 用 `bg-green-500` 而非 CSS 变量）；`focus-visible:ring-0` 移除了焦点环影响键盘可达性；消息流无虚拟化在长 thread 下卡顿。
+
+用户决策：**全栈式优化** + **硬 fork（不再考虑 upstream merge）** + **必须支持 mp4/png/jpg 预览**。
+
+---
+
+## 实施分期
+
+按 PR 大小切分为 5 个 phase，每个 phase 独立可 ship 并通过 `pnpm dev` 验证。建议每个 phase 一个 PR，便于 review。
+
+---
+
+### Phase A — Foundation polish（设计 token + dark mode + a11y）
+
+**目标：** 修掉所有硬编码视觉值、补全 dark mode、恢复焦点环。无新增功能，只是清理。
+
+**关键改动：**
+
+1. **Token 化品牌色** — `src/app/globals.css`
+   - 新增语义 token：`--brand-accent`（替代 `#2F6868`）、`--badge-count-bg`、`--subagent-name`、`--subagent-chevron`，light/dark 各定义一份
+   - 把 `STATUS_COLORS` 也搬到 CSS 变量：`--status-idle / --status-busy / --status-interrupted / --status-error`，并在 dark 模式下使用降饱和度变体
+
+2. **替换硬编码颜色**
+   - `src/app/components/ChatInterface.tsx:441,487` — `bg-[#2F6868]` → `bg-[hsl(var(--brand-accent))]`
+   - `src/app/components/SubAgentIndicator.tsx:26,33` — `text-[#3F3F46]` / `text-[#70707B]` → `text-foreground` / `text-muted-foreground`
+   - `src/app/components/ThreadList.tsx:34-39` — `STATUS_COLORS` 改读 CSS 变量
+   - `src/app/components/ToolApprovalInterrupt.tsx:270,272` — 把 `dark:bg-green-600` 等独立 dark 写法整合进语义 token
+   - `src/app/page.tsx:159` — `border-[#2F6868] bg-[#2F6868]` → 用 `--brand-accent`
+
+3. **恢复焦点环**
+   - `src/app/components/ToolCallBox.tsx:117` 等所有出现 `focus-visible:ring-0 focus-visible:ring-offset-0` 的位置 — 改回 `focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2`
+   - `globals.css:14-16` 已有 `outline-color: hsl(var(--primary))` 全局规则，保留并验证不被覆盖
+
+4. **ARIA / 语义化补齐**
+   - `ChatInterface.tsx:365-424` task summary 按钮 — 新增 `aria-label="View milestone tasks"` / `aria-label="View output files"`
+   - `ThreadList.tsx:329-336` status 圆点 — 包一层 `<span role="status" aria-label={`Status: ${status}`}>`
+   - `SubAgentIndicator.tsx` Button — `aria-expanded={isExpanded}` + `aria-controls`
+
+5. **可读性补丁**
+   - `ChatMessage.tsx:111` user message 在 dark 下 `--color-user-message-bg: #2d2d2d` 但 `text-foreground` 对比度足够，验证后保留；如不达标则在 dark 下改用 `bg-secondary`
+   - 字号统一：去掉 `text-[10px]`、`text-[15px]` 等异类，统一到 tailwind scale `xxs/xs/sm/base`（已在 `tailwind.config.mjs` 定义）
+
+**修改文件：** `globals.css`, `tailwind.config.mjs`(可选), `ChatInterface.tsx`, `SubAgentIndicator.tsx`, `ThreadList.tsx`, `ToolApprovalInterrupt.tsx`, `ToolCallBox.tsx`, `page.tsx`, `ChatMessage.tsx`
+
+---
+
+### Phase B — Video-Maker Workflow 可视化（milestone + subagent 派发树）
+
+**目标：** 让用户一眼看出 video-maker 处于哪个 milestone、哪些 subagent 在跑、它们之间什么关系。这是这次优化的最大价值点。
+
+**新增组件：**
+
+1. **`src/app/components/MilestonePipeline.tsx`** — 顶部水平进度条
+   - 4 个 step：Research / Script / Assets / Assembly
+   - 每个 step 三态：pending（灰）/ running（深青脉冲）/ completed（绿√）
+   - 视觉：水平 stepper，连接线 + 圆形 step + 标签 + 百分比 hint
+   - 数据源：解析 `todos[]` 中的 `content` 文本（约定关键词如 "research"/"script"/"assets"/"assembly"），或解析 `files[]` 出现哪个产物（`research.md` 完成 → research done；`manifest.json` → assets done；`video.mp4` → assembly done）
+   - 推荐放在 `page.tsx` header 下方、`ResizablePanelGroup` 上方，全宽显示
+
+2. **`src/app/lib/milestones.ts`** — milestone 推导逻辑
+   - `inferMilestoneFromTodos(todos): Record<MilestoneKey, status>`
+   - `inferMilestoneFromFiles(files): Record<MilestoneKey, status>`
+   - 合并两者 → 返回 `{milestone, label, status, percent, activeStep}`
+   - 单元可测，不依赖 React
+
+3. **`src/app/components/SubAgentTree.tsx`** — 替换 `ChatMessage.tsx:150-193` 的扁平 subagent 列表
+   - 解析 message 间的派发关系（parent ai message → task tool_call → child subagent → 它产生的下层 task tool_call）
+   - 用 indentation + 连接线（`border-l-2 border-border`）渲染父子层级
+   - 每个节点显示：`subAgentName`（researcher / scriptwriter / scene-batch-generator）+ status（running spinner / completed √ / failed ⚠）+ 输入/输出折叠按钮
+   - 保留现有"展开看 input/output"行为，但持久化到 localStorage（key `subagent-expanded-${threadId}`），避免切换 thread 重置
+
+4. **Task 按 milestone 分组** — `src/app/components/ChatInterface.tsx:341-546`
+   - 当前按 `pending/in_progress/completed` status 分组；改为先按 milestone 分组、再按 status 分组（或加个 toggle）
+   - 每个 milestone 子组显示 `Tasks 3/8 done`
+   - milestone 推导用 Phase B 的 `lib/milestones.ts`
+
+**修改文件：** 新增 3 个组件 + `lib/milestones.ts`；改 `ChatInterface.tsx`, `ChatMessage.tsx`, `page.tsx`
+
+---
+
+### Phase C — 媒体预览 & 文件–milestone 关联（用户明确要求）
+
+**目标：** 让 mp4 / png / jpg 在 UI 中可直接预览；让 Files 列表按 milestone 分组，每个文件标注归属。
+
+**关键改动：**
+
+1. **扩展 `src/app/components/FileViewDialog.tsx`**
+   - 新增 `getMediaType(filename): "video" | "image" | "audio" | "text"`
+   - `.mp4 / .webm / .mov` → `<video controls preload="metadata" />` + 下载按钮
+   - `.png / .jpg / .jpeg / .webp / .gif` → `<img alt={filename} />` + 缩放/下载
+   - `.mp3 / .wav` → `<audio controls />`
+   - `.json` → 已有的 markdown render fallback，但用 syntax-highlighter 高亮
+   - 数据来源：`files[filename]` 当前是字符串内容；如果是 base64 / data-url，构造 blob URL；如果是文件路径（虚拟路径），构造 `/api/files?path=...` 的 GET 请求（需要 Next.js API route `src/app/api/files/route.ts` 或读 LangGraph state 同步返回）
+
+2. **新增 `src/app/api/files/route.ts`**（仅当 LangGraph state 用虚拟路径时）
+   - 接受 `?path=<virtual-path>` 查询，调 LangGraph SDK 拉取文件 raw bytes
+   - 设置正确 `Content-Type` 头（mp4 / png 等）
+   - 仅本地 dev 用，生产部署再加鉴权
+
+3. **Files 按 milestone 分组** — `src/app/components/TasksFilesSidebar.tsx`
+   - 新增 `inferFileMilestone(filename): MilestoneKey`（通过文件名前缀/后缀匹配：`research.md → research`，`script.md → script`，`manifest.json|*.png|*.mp3 → assets`，`*.mp4 → assembly`）
+   - 网格按 milestone 分组渲染，每组带标题
+   - 每个文件卡片右上角添加 milestone badge（小色块）
+
+4. **缩略图预览** — `TasksFilesSidebar.tsx`
+   - 文件卡片如果是图片，渲染 thumbnail（80×80 cover）
+   - 视频则渲染第一帧（用 `<video>` 加 `preload="metadata"` + `currentTime=0.1`）
+   - 文本/JSON 渲染前 3 行 preview
+
+**修改文件：** `FileViewDialog.tsx`（重写一半）, `TasksFilesSidebar.tsx`, 新增 `lib/file-types.ts`, 可能新增 `app/api/files/route.ts`
+
+---
+
+### Phase D — 性能 & 可靠性
+
+**目标：** 长 thread / 大量消息下不卡，自动滚动可控。
+
+**关键改动：**
+
+1. **消息列表虚拟化** — `ChatInterface.tsx:295-330`
+   - 引入 `react-virtuoso`（package.json 加依赖）替代直接 `.map()`
+   - 配置 `followOutput="smooth"` 让新消息自动滚到底部，但用户主动滚回上方时停止
+   - `useStickToBottom` 与 virtuoso 互斥，移除 `useStickToBottom` 改用 virtuoso 内置行为
+
+2. **Thread list 懒加载阈值优化** — `ThreadList.tsx`
+   - 当前 `limit=20` 手动 Load More；改为 IntersectionObserver 自动预取下一页
+   - 添加搜索框：title fuzzy match（用 lodash `debounce` 300ms）
+
+3. **ResizablePanel resize 防抖** — `page.tsx`
+   - resize 期间消息列表不重新计算高度（virtuoso 会自动处理）
+   - 验证 ResizableHandle 可见性，避免 hover 才出现导致用户找不到
+
+**新增依赖：** `react-virtuoso`（运行时）
+
+**修改文件：** `ChatInterface.tsx`, `ThreadList.tsx`, `page.tsx`
+
+---
+
+### Phase E — 工具审批 & 配置 polish
+
+**目标：** 让 manual audio pause 等中断的审批不再让用户改 raw JSON；让首次配置流畅。
+
+**关键改动：**
+
+1. **ToolApprovalInterrupt 表单化** — `src/app/components/ToolApprovalInterrupt.tsx`
+   - 当前 args 是 textarea（line 135-176 附近）；改为根据 `actionRequest.args` 的字段类型推导：
+     - `string` → `<Input />`
+     - `boolean` → `<Switch />`
+     - `number` → `<Input type="number" />`
+     - `enum`（基于 `reviewConfig` 暗示）→ `<Select />`
+   - 保留"Edit raw JSON"高级模式作为 escape hatch
+   - 字段级别校验错误提示
+
+2. **ConfigDialog 友好化** — `src/app/components/ConfigDialog.tsx`
+   - 顶部加"Quick start"步骤提示（如何在仓库根 `pnpm agent:dev` 起 LangGraph dev）
+   - 新增"Test connection"按钮：发起 `client.assistants.search({graphId, limit:1})` 验证连通性，显示绿/红 badge
+   - Assistant ID 字段下方加"View available assistants"链接，点开下拉显示当前 graph 的 assistants
+   - 用 `alert()`（line 50）改为 inline 错误消息
+
+3. **空状态 / 长加载反馈** — 全局
+   - `ChatInterface.tsx` 当 `isLoading=true` 且 message 增长慢时，每 30s 显示一次 heartbeat（"Researcher is working… 已耗时 1m 23s"）
+   - `page.tsx:255` 欢迎屏增加示例 prompt 卡片（点击直接填入），降低首次使用门槛
+
+**修改文件：** `ToolApprovalInterrupt.tsx`, `ConfigDialog.tsx`, `ChatInterface.tsx`, `page.tsx`
+
+---
+
+## 不在范围内（明确排除）
+
+- 重写后端 LangGraph agent 逻辑（`agent/agent.py` 不动）
+- 改 video-maker skill 本身（`.claude/skills/video-maker/` 不动）
+- 改 LangGraph SDK 协议（`@langchain/langgraph-sdk` 用法不变）
+- i18n / 多语言（保持英文 UI）
+- 移动端响应式（聚焦桌面 desktop ≥ 1024px）
+
+---
+
+## Verification
+
+每个 phase 完成后运行：
+
+1. **静态检查**
+   ```bash
+   cd E:/workspace/orchestrator_skills/deepagent-video-maker-ui
+   corepack yarn lint
+   corepack yarn format:check
+   ```
+
+2. **构建验证**
+   ```bash
+   corepack yarn build
+   ```
+
+3. **E2E 跑通 video-maker 一次完整 session**（最关键）
+   ```bash
+   # 终端 1：起 LangGraph
+   corepack yarn agent:dev
+   # 终端 2：起 UI
+   corepack yarn dev
+   ```
+   - 浏览器打开 `http://localhost:3000`
+   - 用 README 里的示例 prompt 启动一个 video-maker session
+   - 观察：milestone progress bar 是否随 research → script → assets → assembly 推进、subagent tree 是否正确展示父子关系、视频 mp4 在 FileViewDialog 是否能播、focus ring 在 Tab 键导航时可见、dark mode（系统级别切换）是否完整覆盖
+
+4. **可访问性快速过**
+   - Chrome DevTools → Lighthouse Accessibility 跑分（目标 ≥ 95）
+   - 仅键盘操作完成"打开 thread → 发送消息 → 预览视频"全流程
+
+5. **性能验证**
+   - 用一个 200+ 消息的长 thread 滚动，FPS 监控不低于 50
+   - Files 含 1 个 5MB mp4 + 10 个 png，FileViewDialog 切换不卡顿
+
+---
+
+## 关键文件清单
+
+**Phase A 触及：**
+- `src/app/globals.css`
+- `src/app/page.tsx`
+- `src/app/components/ChatInterface.tsx`
+- `src/app/components/ChatMessage.tsx`
+- `src/app/components/SubAgentIndicator.tsx`
+- `src/app/components/ThreadList.tsx`
+- `src/app/components/ToolApprovalInterrupt.tsx`
+- `src/app/components/ToolCallBox.tsx`
+
+**Phase B 触及（新增 + 改）：**
+- 新 `src/app/components/MilestonePipeline.tsx`
+- 新 `src/app/components/SubAgentTree.tsx`
+- 新 `src/app/lib/milestones.ts`
+- 改 `src/app/components/ChatInterface.tsx`, `ChatMessage.tsx`, `page.tsx`
+
+**Phase C 触及：**
+- `src/app/components/FileViewDialog.tsx`（半重写）
+- `src/app/components/TasksFilesSidebar.tsx`
+- 新 `src/app/lib/file-types.ts`
+- 可能新 `src/app/api/files/route.ts`
+
+**Phase D 触及：**
+- `package.json`（加 `react-virtuoso`）
+- `src/app/components/ChatInterface.tsx`
+- `src/app/components/ThreadList.tsx`
+
+**Phase E 触及：**
+- `src/app/components/ToolApprovalInterrupt.tsx`
+- `src/app/components/ConfigDialog.tsx`
+- `src/app/components/ChatInterface.tsx`
+- `src/app/page.tsx`
+
+---
+
+## 复用的现有工具与库
+
+- shadcn 基础组件已具备：`Button / Dialog / Input / Switch / Select / Tabs / Tooltip / ScrollArea / Skeleton`
+- `react-syntax-highlighter` 已在依赖中（用于 JSON / code preview）
+- `react-markdown + remark-gfm` 已在用（保留）
+- `lucide-react` 图标统一来源（避免 emoji icon）
+- `date-fns` 用于时间格式化（已在 ThreadList 用）
+- `clsx + tailwind-merge` 经 `cn()` 合并 className
+- `nuqs` URL state（threadId / sidebar / 可加 milestone tab state）
+
+---
+
+## 估算与建议执行顺序
+
+| Phase | 估算 PR 大小 | 风险 | 顺序 |
+|---|---|---|---|
+| A — Foundation | 中（10-15 文件小改） | 低 | 1️⃣ 先做，让后续基于干净 token |
+| C — 媒体预览 | 中（3-4 文件 + 可能 1 API route） | 中（取决于 LangGraph state 文件传输方式） | 2️⃣ 用户重点诉求，先于 B 验证文件取得 |
+| B — Workflow 可视化 | 大（3 新组件 + 改 3 文件） | 中（milestone 推导逻辑可能需要迭代） | 3️⃣ 价值最高但最复杂，放后面 |
+| D — 性能 | 小-中（2-3 文件 + 1 依赖） | 低 | 4️⃣ 长 thread 出现后必要 |
+| E — Polish | 小（4 文件小改） | 低 | 5️⃣ 收尾 |
+
+每个 Phase 一个 worktree（`feat/ui-phase-a-tokens` 等），独立 PR 合 main。
+
+---
+
+## 待用户在执行阶段确认的小问题
+
+这些不阻塞 plan 通过，等开工时再问：
+
+1. LangGraph state 中 video-maker 输出文件是 base64 内联还是虚拟路径？这决定 Phase C 是否需要新增 `/api/files` route
+2. milestone 名字最终对外用 "Research/Script/Assets/Assembly" 还是中文？（建议英文，与代码一致）
+3. 是否要保留 ConfigDialog 的"首次进入自动弹出"行为，还是改为顶部 banner？

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,16 @@ dependencies = [
   "langchain-anthropic>=0.3.0",
   "langchain-openai>=0.3.0",
   "PyYAML>=6.0",
+  "langchain-community>=0.4.1",
   "tavily-python>=0.7.23",
   "langchain-tavily>=0.2.18",
 ]
 
 [dependency-groups]
-dev = ["pytest>=8.0.0"]
+dev = [
+    "langgraph-cli[inmem]>=0.2",
+    "pytest>=8.0.0",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests/deepagents_video_maker"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
   "langchain-anthropic>=0.3.0",
   "langchain-openai>=0.3.0",
   "PyYAML>=6.0",
+  "tavily-python>=0.7.23",
+  "langchain-tavily>=0.2.18",
 ]
 
 [dependency-groups]

--- a/scripts/deepagents_video_maker.py
+++ b/scripts/deepagents_video_maker.py
@@ -38,11 +38,33 @@ def load_env_files() -> None:
 
 
 def resolve_model(model: Any) -> Any:
-    """Resolve provider shortcuts, including DeepSeek OpenAI-compatible config."""
+    """Resolve provider shortcuts, including DeepSeek and Anthropic-compatible configs."""
     if not isinstance(model, str):
         return model
 
     normalized = model.strip()
+
+    # --- Anthropic-compatible route (ZhipuAI glm-5-turbo, etc.) ---
+    if normalized.startswith("anthropic:"):
+        from langchain_anthropic import ChatAnthropic
+
+        model_name = normalized.split(":", 1)[1]
+        api_key = (
+            os.environ.get("ANTHROPIC_AUTH_TOKEN")
+            or os.environ.get("ANTHROPIC_API_KEY")
+        )
+        if not api_key:
+            raise RuntimeError("anthropic: model requires ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY.")
+        base_url = os.environ.get("ANTHROPIC_BASE_URL") or "https://api.anthropic.com"
+        return ChatAnthropic(
+            model=model_name,
+            api_key=api_key,
+            base_url=base_url,
+            max_retries=5,
+            timeout=120,
+        )
+
+    # --- DeepSeek OpenAI-compatible route ---
     deepseek_requested = normalized.startswith("deepseek:")
     deepseek_env_present = bool(os.environ.get("DEEPSEEK_API_KEY"))
     if not deepseek_requested and not (deepseek_env_present and normalized.startswith("deepseek-")):

--- a/scripts/smoke_invoke.py
+++ b/scripts/smoke_invoke.py
@@ -1,0 +1,79 @@
+"""Real DeepAgents invoke smoke test using ZhipuAI Anthropic-compatible backend.
+
+Uses glm-5-turbo via ZhipuAI's Anthropic-compatible endpoint.
+Credentials are loaded from E:/workspace/orchestrator_skills/.env.
+"""
+from __future__ import annotations
+import os, sys, time, traceback
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+ORCHESTRATOR_SKILLS_ENV = Path(r"E:\workspace\orchestrator_skills\.env")
+
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+os.environ.setdefault("ORCHESTRATOR_SKILLS_ROOT", str(PROJECT_ROOT))
+os.environ["LANGSMITH_TRACING"] = "false"
+
+# Load credentials from orchestrator_skills/.env
+for line in ORCHESTRATOR_SKILLS_ENV.read_text(encoding="utf-8").splitlines():
+    line = line.strip()
+    if not line or line.startswith("#") or "=" not in line:
+        continue
+    k, v = line.split("=", 1)
+    if k in ("ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL", "ANTHROPIC_MODEL",
+             "ANTHROPIC_DEFAULT_SONNET_MODEL", "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+             "LANGSMITH_API_KEY", "LANGSMITH_ENDPOINT", "LANGSMITH_PROJECT"):
+        os.environ[k] = v
+
+# Load TAVILY_API_KEY from project .env
+for line in (PROJECT_ROOT / ".env").read_text(encoding="utf-8").splitlines():
+    line = line.strip()
+    if line.startswith("TAVILY_API_KEY="):
+        os.environ["TAVILY_API_KEY"] = line.split("=", 1)[1]
+        print(f"[INFO] TAVILY_API_KEY loaded")
+        break
+
+# Enable LangSmith tracing
+os.environ["LANGSMITH_TRACING"] = "true"
+os.environ["LANGCHAIN_TRACING_V2"] = "true"
+os.environ["LANGCHAIN_CALLBACKS_BACKGROUND"] = "false"
+os.environ.setdefault("LANGSMITH_PROJECT", "deepagents-video-maker-smoke")
+print(f"[INFO] LangSmith tracing enabled, project={os.environ['LANGSMITH_PROJECT']}")
+
+from langchain_anthropic import ChatAnthropic  # noqa: E402
+from deepagents_video_maker.agent import create_video_maker_agent  # noqa: E402
+
+model = ChatAnthropic(
+    model=os.environ.get("ANTHROPIC_MODEL", "glm-5-turbo"),
+    api_key=os.environ["ANTHROPIC_AUTH_TOKEN"],
+    base_url=os.environ.get("ANTHROPIC_BASE_URL", "https://open.bigmodel.cn/api/anthropic"),
+    timeout=120,
+    max_retries=2,
+)
+agent = create_video_maker_agent(model, project_root=PROJECT_ROOT)
+print("[OK] agent built:", type(agent).__name__)
+
+prompt = "Create a 30-second video about AI technology trends 2025. Use websearch to gather up-to-date information."
+print(f"[INFO] prompt: {prompt}")
+print("[INFO] invoking agent (real LLM)...")
+
+start = time.time()
+try:
+    result = agent.invoke(
+        {"messages": [{"role": "user", "content": prompt}]},
+        config={"configurable": {"thread_id": "smoke-real-001"}, "recursion_limit": 150},
+    )
+    elapsed = time.time() - start
+    messages = result.get("messages", [])
+    print(f"[OK] invoke done in {elapsed:.1f}s, messages={len(messages)}")
+    if messages:
+        last = messages[-1]
+        content = last.content if hasattr(last, "content") else str(last)
+        print(f"[OK] last msg type={getattr(last, 'type', type(last).__name__)}")
+        print("[OK] response preview:")
+        print(str(content)[:800])
+except Exception as e:
+    elapsed = time.time() - start
+    print(f"[ERROR] after {elapsed:.1f}s: {type(e).__name__}: {e}")
+    traceback.print_exc()
+    sys.exit(1)

--- a/skills/feature-pipeline/SKILL.md
+++ b/skills/feature-pipeline/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: feature-pipeline
+description: Use when implementing a new feature in deepagents-video-maker end-to-end with minimal supervision, or when you need a single entry point that orchestrates plan → design → implement → verify → ship for this repo. Triggers — "新 feature"、"feature pipeline"、"自动开发"、"ship feature"。
+---
+
+# /feature-pipeline — End-to-End Feature 自动化流水线
+
+你是 **Pipeline Orchestrator**。你按固定阶段把一个 feature 从 idea 推进到 merged PR,每一步调用一个对应的 superpowers / 项目 skill,关键节点设 gate。本 skill 不实现具体技术工作,只负责调度。
+
+## 0. 项目上下文(每次开局必读)
+
+- Python 命令一律 `uv run ...`,Node 一律 `pnpm ...`
+- 测试入口:`uv run pytest tests/deepagents_video_maker -q` + `uv run python scripts/deepagents_video_maker.py --check`
+- Lint/Type:`uv run ruff check`、`pnpm -w lint`(若有)
+- Plan 目录:`docs/plans/YYYY-MM-DD-<slug>.md`
+- 主分支:`master`,feature 走 worktree
+
+## 1. 阶段映射
+
+| # | 阶段 | 主 Skill | 辅助 Skill | 产物 | Gate |
+|---|------|----------|-----------|------|------|
+| 1 | Plan | `superpowers:brainstorming` → `superpowers:writing-plans` | (人工提需求,不自动澄清) | `docs/plans/YYYY-MM-DD-<slug>.md` | **人工批准 plan** |
+| 2 | Design | `plan-eng-review` | `plan-ceo-review`、`plan-design-review`(仅含 UI 时) | plan.md 增补 architecture / data flow / test plan 章节 | 自动通过(reviewer 输出 OK) |
+| 3 | Implement | `superpowers:executing-plans` | `superpowers:subagent-driven-development`(并行子任务)+ `superpowers:using-git-worktrees`(隔离)+ `superpowers:test-driven-development`(每子任务先写测试)+ `superpowers:systematic-debugging`(失败时) | feature 分支上的 commits | 自动 |
+| 4 | Verify | `superpowers:verification-before-completion` | `superpowers:requesting-code-review` + `code-review` + `qa`(若有 UI) | 测试全绿 + review 报告 | 自动 |
+| 5 | Ship | `superpowers:finishing-a-development-branch` | `/ship` → **人工签批** → `/land-and-deploy` → `/canary` | merged PR + 部署成功 | **人工签批 ship** |
+
+## 2. 用户确认的三条规则(不可改)
+
+1. **Plan 阶段不自动澄清需求** — 由用户提需求 / 直接给出 spec。`writing-plans` 完成后必须停下,让用户批准 plan 文件,才能进入 Design。
+2. **失败回退策略** — 任意阶段失败:
+   - 失败次数 ≤ 2 次 → 回到 **Implement** 阶段(同一 worktree 内修复)
+   - 失败次数 > 2 次 → 回到 **Plan** 阶段(在 plan.md 中追加 "Failure Notes" 段,要求用户重新批准)
+   - 失败计数器写在 plan.md frontmatter:`retry_count: N`
+3. **Ship 前人工签批** — Verify 通过后,Pipeline 必须调用 AskUserQuestion "Ship now?" 选项 [ship] [hold] [abort],收到 ship 才执行 `/land-and-deploy`。
+
+## 3. 主编排流程(B 方案,默认)
+
+### 3.1 入口
+
+```
+用户: /feature-pipeline <feature 描述 或 plan 文件路径>
+```
+
+如果传入的是描述,跳到 3.2;如果传入的是 `.md` 路径且 frontmatter 有 `status: approved`,跳到 3.3。
+
+### 3.2 Plan 阶段
+
+1. `Skill: superpowers:brainstorming` — 与用户探讨问题、不变量、备选方案
+2. `Skill: superpowers:writing-plans` — 产出 `docs/plans/YYYY-MM-DD-<slug>.md`,frontmatter 包含:
+   ```yaml
+   ---
+   feature: <slug>
+   status: draft           # draft | approved | in_progress | done | failed
+   retry_count: 0
+   created_at: <date>
+   ---
+   ```
+3. **STOP** — AskUserQuestion "Plan 已写入 `<path>`,批准吗?" 选项 [approve] [revise] [abort]
+   - `approve` → 写回 `status: approved`,进入 3.3
+   - `revise` → 收集反馈,回到第 1 步
+   - `abort` → 退出
+
+### 3.3 Design 阶段
+
+1. `Skill: plan-eng-review` — 强制走架构 / 数据流 / 边界 / 测试覆盖 / 性能 5 维评审,把结果追加到 plan.md
+2. 若 plan 涉及 `web-ui/` → `Skill: plan-design-review`
+3. 若 plan 改变产品定位 → `Skill: plan-ceo-review`
+4. Reviewer 给出 verdict:
+   - `pass` → 进入 3.4
+   - `revise` → 失败计数 +1,按 §2.2 规则回退
+
+### 3.4 Implement 阶段
+
+1. `Skill: superpowers:using-git-worktrees` — 创建 `worktrees/<slug>` 隔离工作区,新分支 `feat/<slug>`
+2. 把 plan.md 中 task 列表塞给 `Skill: superpowers:executing-plans`,内部按需用 `superpowers:subagent-driven-development` 并行
+3. 每个子任务**强制** TDD:`Skill: superpowers:test-driven-development`,先写失败测试再实现
+4. 子任务实现遇 bug → `Skill: superpowers:systematic-debugging`,根因优先
+5. 每完成一个 task,跑项目级验证钩(见 §0),不通过则当作 task 失败重试
+
+### 3.5 Verify 阶段
+
+1. `Skill: superpowers:verification-before-completion` — 跑完整测试矩阵:
+   ```bash
+   uv run ruff check
+   uv run pytest tests/deepagents_video_maker -q
+   uv run python scripts/deepagents_video_maker.py --check
+   pnpm -w lint    # 若 web-ui 有改动
+   ```
+2. `Skill: superpowers:requesting-code-review` — 内部 review pass 内容
+3. 若 plan 涉及 `web-ui/` → `Skill: qa` 跑无头浏览器主路径
+4. 任意一步失败 → 失败计数 +1,按 §2.2 规则回退
+
+### 3.6 Ship 阶段(人工签批)
+
+1. **STOP** — AskUserQuestion "Verify 全绿,准备 ship。继续?"
+   选项 [ship] [hold] [abort]
+2. `ship` → `Skill: ship`(创建 PR)→ AskUserQuestion "PR 已创建 `<url>`,land?" [land] [hold]
+3. `land` → `Skill: land-and-deploy` → `Skill: canary` 验证生产健康
+4. 写回 plan.md `status: done`,记录 PR url 和合并 commit
+
+### 3.7 长期循环驱动(可选)
+
+如果用户希望"无人值守"地推进 implement / verify 阶段(例如夜里跑),从 3.4 起套上 `ralph-loop`:
+
+```
+/ralph-loop
+  goal: 把 docs/plans/<slug>.md 中所有 task 标记为 done,verify 全绿
+  budget: 8h
+  on_failure: 按 SKILL §2.2 规则回退,把失败原因写入 plan.md "Failure Notes"
+```
+
+ralph-loop 不要跨 Ship gate,Ship 永远停在人面前。
+
+## 4. C 方案 — 拆 schedule 任务(未来扩展,暂不启用)
+
+把流水线拆成 5 个独立 schedule routine(`feat-plan` / `feat-design` / `feat-implement` / `feat-verify` / `feat-ship`),通过 plan.md frontmatter 的 `status` 字段做状态机驱动,routine 之间不直接通信、只通过文件交换状态。适用于跨日 / 需要离线等待 / 多 feature 并行的场景。
+
+**完整规格见 [scheme-c-schedule.md](scheme-c-schedule.md)**,包含:
+- 状态机所有状态、转换规则、约束(§3)
+- 每个 routine 的触发、入口状态、动作、失败处理(§4)
+- 锁协议、worktree 互斥、多 feature 并行(§5)
+- 用户操作指南(§7)、观测日志(§8)
+- B → C 切换路径(§9)、Routine prompt 骨架(§10)
+- 当前不启用原因 + 触发切换的明确信号(§11)
+
+切换信号(任一即考虑):单 feature > 24h、需等外部依赖、≥3 feature 并行。
+
+## 5. Quick Reference
+
+```
+启动: /feature-pipeline "feature 描述"
+恢复: /feature-pipeline docs/plans/2026-04-27-foo.md
+状态: cat docs/plans/<slug>.md | head -10   # 看 frontmatter
+中止: 编辑 plan.md status: aborted
+```
+
+| 想做 | 用 |
+|------|----|
+| 新 feature 从 0 开始 | `/feature-pipeline "<描述>"` |
+| 已批准 plan 接着跑 | `/feature-pipeline <plan 路径>` |
+| 夜跑 implement+verify | 在 3.4 起包 `/ralph-loop` |
+| 失败原因排查 | 看 plan.md "Failure Notes" 段 |
+| 跳过 design 评审(原型期) | plan.md frontmatter 加 `skip_design: true` |
+
+## 6. Common Mistakes
+
+- **跳过 Plan gate** — 不能因为"需求很清楚"就直接进 Implement。Plan gate 是这套流程的根。
+- **失败计数错位** — 计数器是"feature 累计失败"不是"阶段累计"。任何阶段失败都计入同一个 retry_count。
+- **Ship 自动化** — 永远不要把 §3.6 的 AskUserQuestion 换成自动通过。即使 verify 全绿,production 部署是人决定的。
+- **Worktree 泄漏** — feature done 后必须用 `superpowers:finishing-a-development-branch` 清理 worktree,否则会污染主仓库。
+- **Plan 写完就开干** — `writing-plans` 完成不等于 plan 批准。frontmatter `status` 必须显式置 `approved`。
+
+## 7. Red Flags
+
+- "这个 feature 很小,跳过 design 直接 implement" → 用 `skip_design: true` 显式声明,而不是悄悄跳过
+- "verify 失败 3 次了,我手动 fix 一下就 ship" → 触发 §2.2 第二条,必须回 Plan
+- "用户没回我,我先 ship 着" → 永远等。ship gate 不超时
+- "ralph-loop 跨过 Ship gate 了" → 立即 cancel-ralph,人工接管

--- a/skills/feature-pipeline/scheme-c-schedule.md
+++ b/skills/feature-pipeline/scheme-c-schedule.md
@@ -1,0 +1,352 @@
+# 方案 C — Schedule Routine 拆分流水线(详细规格)
+
+> 状态:**草稿,未启用**。当前默认走方案 B(SKILL.md §3)。本文档定义将来需要切换到 C 时的完整规格。
+
+## 1. 设计动机
+
+方案 B 把整条 plan→ship 流水线塞在一个会话里运行,要求:
+- 一直有人或 ralph-loop 在线
+- 单个 feature 在合理时间内能跑完(< 24h)
+- 不需要等待外部异步事件
+
+当现实违反任一条件时,会话级编排会退化成"停在某一步等",浪费上下文窗口和注意力。方案 C 把每阶段拆成独立 routine,通过文件状态机协作,每个 routine 启动时检查状态、做一步、写回状态、退出 — 真正的离线驱动。
+
+### 1.1 适用场景
+
+满足以下任一即考虑切换到 C:
+
+| 触发条件 | 例子 |
+|----------|------|
+| 单 feature 平均 > 24h | 涉及大模型训练、数据回流、外部供应商响应 |
+| Implement 阶段需要等待外部依赖 | 等人工标注、第三方 API rate limit、白名单审批 |
+| 多 feature 并行 | 同时推 3+ 个 feature,每个进度不一 |
+| 跨时区协作 | 设计/产品在另一时区批 plan,实现可在夜里跑 |
+
+### 1.2 不适用场景
+
+- 一次性 PoC、bugfix、文档改动 → 直接 B 方案
+- feature 全程 < 4h → routine 调度开销不划算
+- 没有可信 CI / 测试覆盖 → 自动化没有兜底,失败会放大
+
+## 2. 整体架构
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  docs/plans/<slug>.md  ←── 单一事实源(状态 + 任务 + 失败记录)        │
+└──────────────────────────────────────────────────────────────────────┘
+        ▲                ▲                ▲                ▲
+        │                │                │                │
+   ┌────┴────┐      ┌────┴─────┐    ┌─────┴─────┐    ┌─────┴─────┐
+   │feat-plan│ ───> │feat-     │──> │feat-      │──> │feat-      │──> [ship gate]
+   │(on-     │      │design    │    │implement  │    │verify     │       │
+   │ demand) │      │(1h cron) │    │(30m cron) │    │(1h cron)  │       ▼
+   └─────────┘      └──────────┘    └───────────┘    └───────────┘   ┌──────────┐
+                                          │                          │feat-ship │
+                                          │ uses                     │(on-      │
+                                          ▼                          │ demand)  │
+                                    ┌──────────┐                     └──────────┘
+                                    │ worktrees│
+                                    │ /<slug>/ │
+                                    └──────────┘
+```
+
+每个 routine 是独立的远程 agent,它们之间**不直接通信**,只通过两份共享物:
+- **plan.md**:状态机驱动 + 任务清单 + 失败记录
+- **worktree** `worktrees/<slug>`:代码工作区,git 分支 `feat/<slug>`
+
+## 3. plan.md 状态机
+
+### 3.1 完整 frontmatter schema
+
+```yaml
+---
+# 标识
+feature: <slug>                 # kebab-case,< 30 字符
+created_at: 2026-04-27T14:00:00+08:00
+owner: <github-handle>          # 谁负责签批
+
+# 状态机(核心)
+status: draft                   # 见 3.2
+status_history:                 # 状态转换审计
+  - { ts: ..., from: draft, to: pending_approval, by: feat-plan }
+  - { ts: ..., from: pending_approval, to: approved, by: human }
+locked_by: null                 # 当前持有写锁的 routine 名;null 表示空闲
+locked_at: null
+
+# 失败计数
+retry_count: 0                  # 跨阶段累计
+last_failure:
+  stage: verify
+  reason: "pytest deepagents_video_maker/test_agent.py::test_foo failed"
+  ts: ...
+
+# 工作区
+worktree_path: worktrees/<slug>
+branch: feat/<slug>
+
+# 配置开关
+skip_design: false
+skip_qa: false                  # 无 UI 改动可跳过
+quality_threshold: standard     # standard | strict
+
+# 产物
+pr_url: null                    # ship 完成后填
+merged_commit: null
+
+---
+```
+
+### 3.2 状态枚举与转换
+
+| 状态 | 含义 | 谁能写入 | 下一可达状态 |
+|------|------|----------|--------------|
+| `draft` | 由 feat-plan 写入草稿,等用户批 | feat-plan | `pending_approval` |
+| `pending_approval` | plan 写完,等用户人工批准 | feat-plan | `approved`(人) / `aborted`(人) |
+| `approved` | 用户批了,等 feat-design 拉取 | human / 系统(回退时) | `designing`(feat-design 启动) / `aborted` |
+| `designing` | feat-design 运行中(临时态) | feat-design | `designed` / `revise_needed` / `failed` |
+| `designed` | 设计评审通过,等 feat-implement | feat-design | `implementing` |
+| `implementing` | feat-implement 运行中 | feat-implement | `implemented` / `revise_needed` / `failed` |
+| `implemented` | 所有 task 完成,等 feat-verify | feat-implement | `verifying` |
+| `verifying` | feat-verify 运行中 | feat-verify | `verified` / `revise_needed` / `failed` |
+| `verified` | verify 全绿,等用户签批 ship | feat-verify | `shipping`(用户触发) / `aborted` |
+| `shipping` | feat-ship 运行中 | feat-ship | `done` / `failed` |
+| `done` | 已 merge + 部署成功 | feat-ship | (终态) |
+| `revise_needed` | 当前阶段失败,等回退处理 | 任意 routine | `approved`(<=2) / `draft`(>2) |
+| `failed` | 不可恢复(罕见) | 任意 routine | (终态,需人工介入) |
+| `aborted` | 用户中止 | human | (终态) |
+
+### 3.3 转换规则约束
+
+- `*-ing` 是临时态,routine 退出前必须转出。如 routine 异常崩溃留下 `*-ing`,下次启动时检测到 `locked_at` 超过 30 分钟,自动 unlock 并重新进入。
+- `aborted`、`done`、`failed` 是终态,任何 routine 检测到立即退出。
+- `revise_needed` 是回退枢纽:
+  - retry_count <= 2 → 自动写回 `approved`(轻度回退,重新走 design+implement+verify)
+  - retry_count > 2 → 写回 `draft`(重度回退,要求用户改 plan 或追加约束),并把失败原因写入 plan.md 正文 "Failure Notes" 段
+
+## 4. 各 Routine 详细规格
+
+每个 routine 启动时的固定开场白:
+```
+1. 锁:CAS 把 plan.md 的 locked_by 从 null 改成自己;失败立即退出
+2. 状态匹配:不在自己的触发状态里 → 解锁,退出
+3. 转入 *-ing 状态,记录 status_history
+4. 干活
+5. 转出 *-ing 到 next/error 状态,记录
+6. 解锁,退出
+```
+
+### 4.1 `feat-plan`
+
+| 字段 | 值 |
+|------|----|
+| 触发 | on-demand(用户跑 `/schedule run feat-plan --plan <slug>`) |
+| 入口 status | `draft` 或不存在 |
+| 用 Skill | `superpowers:brainstorming` → `superpowers:writing-plans` |
+| 输入 | 用户给的 feature 描述(命令行参数) |
+| 输出 | `docs/plans/<date>-<slug>.md`,frontmatter `status: pending_approval` |
+| 失败处理 | 写 `status: failed`,正文记录失败原因 |
+| 不做 | 不写代码,不动 worktree |
+
+注:`writing-plans` 完成后**不再询问用户**,直接停在 `pending_approval`,等用户在另一个会话里把 status 改成 `approved`(或者用 `feat-approve` 辅助命令一行改)。
+
+### 4.2 `feat-design`
+
+| 字段 | 值 |
+|------|----|
+| 触发 | cron `0 * * * *`(每小时 0 分) |
+| 入口 status | `approved` |
+| 用 Skill | `plan-eng-review`(必),`plan-design-review`(若 plan 涉及 web-ui),`plan-ceo-review`(若 plan 改产品定位) |
+| 动作 | 加锁 → 状态转 `designing` → 跑评审,把结果**追加**到 plan.md 正文 "Design Review" 段 → 评分通过(各维度 ≥ 7/10)则转 `designed`,否则 `revise_needed` 并 retry_count +1 |
+| 失败处理 | 评审报错(非评分低)→ `failed` |
+| 幂等性 | 若 plan.md 已存在 "Design Review" 段且时间戳在 24h 内,跳过,直接转 `designed` |
+
+### 4.3 `feat-implement`
+
+| 字段 | 值 |
+|------|----|
+| 触发 | cron `*/30 * * * *`(每 30 分) |
+| 入口 status | `designed` 或 `implementing`(续跑) |
+| 用 Skill | `superpowers:using-git-worktrees`(首次)、`superpowers:executing-plans`、`superpowers:test-driven-development`、`superpowers:systematic-debugging` |
+| 动作 | 加锁 → 状态转 `implementing` → 检查 worktree,不存在则创建 → 取 plan.md 任务清单中第一个未完成 task → TDD 实现 → 提交 → 跑项目级 lint/test → 标 task 完成 → 若所有 task 完成则状态转 `implemented`,否则保持 `implementing` 等下次 tick |
+| 单次 tick 时间盒 | 最多 25 分钟,超时强制保存进度后退出(避免下次 tick 撞车) |
+| 失败处理 | 单 task 失败 ≤ 2 次 → 下次 tick 重试同一 task;> 2 次 → 状态转 `revise_needed`,retry_count +1 |
+| 关键约束 | 必须 `git push` 推到远程的 `feat/<slug>` 分支,让其他 routine / 用户能看到进度 |
+
+### 4.4 `feat-verify`
+
+| 字段 | 值 |
+|------|----|
+| 触发 | cron `30 * * * *`(每小时 30 分,与 feat-design 错开) |
+| 入口 status | `implemented` |
+| 用 Skill | `superpowers:verification-before-completion`、`superpowers:requesting-code-review`、`code-review`、`qa`(若 web-ui 有改动) |
+| 动作 | 加锁 → 状态转 `verifying` → 在 worktree 里跑完整验证矩阵 → 全绿则转 `verified`,任意一项失败转 `revise_needed` 并 retry_count +1 |
+| 验证矩阵 | `uv run ruff check` + `uv run pytest tests/deepagents_video_maker -q` + `uv run python scripts/deepagents_video_maker.py --check` + `pnpm -w lint` + `qa`(条件触发) |
+| 失败记录 | 失败详情写入 plan.md "Verify Run #N" 段 |
+
+### 4.5 `feat-ship`
+
+| 字段 | 值 |
+|------|----|
+| 触发 | on-demand,**用户手动触发**(`/schedule run feat-ship --plan <slug>` 或 RemoteTrigger 信号) |
+| 入口 status | `verified` |
+| 用 Skill | `superpowers:finishing-a-development-branch`、`/ship`、`/land-and-deploy`、`/canary` |
+| 动作 | 加锁 → 状态转 `shipping` → 确认 frontmatter `owner` 字段与触发用户匹配(防误触)→ 创建 PR → 轮询 CI → merge → 部署 → canary 通过 → 状态转 `done`,写入 `pr_url` 和 `merged_commit` |
+| 失败处理 | 任意一步失败 → `failed`(不自动重试,人工介入) |
+| 关键约束 | **绝不能放在 cron 上**。把 ship 设成定时任务等于把生产部署交给时钟,违反"ship 前人工签批"。 |
+
+## 5. 并发与互斥
+
+### 5.1 锁协议
+
+plan.md frontmatter `locked_by` 是软锁,基于乐观并发控制:
+
+1. routine 启动后读 plan.md
+2. 如果 `locked_by != null`:
+   - 检查 `locked_at`,若 > 30 分钟则视为僵死锁,强制解锁并继续
+   - 否则退出(下次 cron 再试)
+3. 写入 `locked_by: <self>, locked_at: <now>`,**带 git commit**(.md 落盘)
+4. 干活
+5. 退出前清空锁,git commit
+
+由于 plan.md 在 git 里,push/pull 即天然 CAS:推时若上游已变,routine 退出。
+
+### 5.2 worktree 互斥
+
+同一 worktree 同时只能有一个 routine 操作。`feat-implement` 是唯一的写入者,其他只读。`feat-verify` 在 verify 期间不修改代码,只跑命令。
+
+### 5.3 多 feature 并行
+
+每个 feature 独立 plan.md + worktree,routine 启动时扫描 `docs/plans/*.md`,只处理 status 命中自己的那些。多个 feature 同时进入 implement 不冲突(不同 worktree)。
+
+## 6. 错误处理与回退
+
+### 6.1 阶段失败回退路径
+
+```
+            ┌──────────────────────────────────────────┐
+            │                                          │
+            ▼                                          │
+   ┌──────────────┐    retry+1 <=2    ┌─────────────┐  │
+   │ revise_needed│ ─────────────────>│  approved   │──┘
+   └──────────────┘                   └─────────────┘
+            │ retry+1 >2
+            ▼
+   ┌──────────────┐
+   │    draft     │  ← 写入 "Failure Notes",等用户改 plan
+   └──────────────┘
+```
+
+### 6.2 不可恢复错误(`failed`)
+
+下列情况直接 `failed`,不自动回退:
+- worktree 损坏(git 状态混乱无法清理)
+- ship 失败(merge 冲突 / CI 红 / 部署失败)
+- routine 崩溃 3 次以上(连续锁超时被强制解锁)
+
+`failed` 后所有 routine 跳过这个 plan,等人工介入。
+
+### 6.3 用户中止
+
+任何时候,把 plan.md frontmatter 改成 `status: aborted` 即可。下次 routine 启动检测到立即退出。
+
+## 7. 用户操作指南(将来启用后)
+
+### 7.1 启动一个 feature
+
+```bash
+# 1. 写 plan
+/schedule run feat-plan --feature "新需求描述"
+# 等 routine 完成,plan.md status = pending_approval
+
+# 2. 审 plan(在 IDE 里读)
+$EDITOR docs/plans/2026-04-27-foo.md
+
+# 3. 批准
+/schedule run feat-approve --plan docs/plans/2026-04-27-foo.md
+# 这是辅助 routine,只改 status: pending_approval -> approved
+
+# 4. 然后什么都不用做,cron routine 自动推进 design / implement / verify
+```
+
+### 7.2 看进度
+
+```bash
+# 看所有进行中的 plan
+ls docs/plans/*.md | xargs head -15 | grep -E '^(feature|status):'
+
+# 看某个 feature 详情
+cat docs/plans/2026-04-27-foo.md
+```
+
+### 7.3 ship
+
+```bash
+# verify 完成后,plan.md status = verified
+# 用户手动触发(等于按下"发布"按钮)
+/schedule run feat-ship --plan docs/plans/2026-04-27-foo.md
+```
+
+### 7.4 干预
+
+| 想做 | 怎么做 |
+|------|--------|
+| 暂停某 feature | 改 status: aborted(可以再改回来,但 retry_count 不会重置) |
+| 跳过 design 评审 | 在 frontmatter 加 `skip_design: true`,feat-design 看到直接转 `designed` |
+| 强制重跑 verify | 改 status: implemented |
+| 加新任务 | 编辑 plan.md task 列表,即使 status 已是 implementing 也行(routine 下次 tick 会发现新 task) |
+
+## 8. 观测与日志
+
+每个 routine 把 stdout/stderr 写到:
+```
+docs/plans/<slug>.logs/
+  feat-plan-<ts>.log
+  feat-design-<ts>.log
+  feat-implement-<ts>.log
+  ...
+```
+
+不要存到 `worktrees/`,因为 worktree 会被删。`docs/plans/` 进 git。日志文件超过 10 MB 自动 truncate(保留首尾各 5 MB)。
+
+## 9. 切换路径(B → C)
+
+切换是单向的,且**只对新 feature 生效**(进行中的 feature 继续走 B 直到 done)。步骤:
+
+1. **建 routine**:用 `Skill: schedule` 分别创建 5 个 routine(prompt 模板见 §10),先全部 `paused`
+2. **冷启动 dry-run**:挑一个低风险 feature,手动一次次触发 `/schedule run feat-* --plan ...`,确认每个 routine 行为正确、状态机流转无误
+3. **开 cron**:把 feat-design / feat-implement / feat-verify 三个改成 `active`,观察 24h
+4. **切换 SKILL.md 默认**:在 [skills/feature-pipeline/SKILL.md](SKILL.md) 把"默认走 §3"改成"默认走 §4",并把 §3(B 方案)标记为"快速通道,适合小改动"
+5. **保留 B 方案**:不删除,因为小 feature 直接 B 更快
+
+## 10. Routine prompt 模板(预留)
+
+每个 routine 是独立 agent,prompt 必须自包含。骨架:
+
+```
+你是 deepagents-video-maker 项目的 <ROUTINE-NAME> routine。
+
+每次唤醒,严格执行:
+1. 扫描 docs/plans/*.md,过滤 frontmatter status == "<MY-TRIGGER-STATUS>"
+2. 对每个匹配的 plan:
+   a. 尝试加锁(CAS locked_by),失败则跳过
+   b. 状态转 <MY-RUNNING-STATE>,git commit + push
+   c. 调用 Skill <MY-PRIMARY-SKILL>,按 SKILL.md §<SECTION> 执行
+   d. 根据结果转出状态(<NEXT-STATE> / revise_needed / failed)
+   e. 解锁,git commit + push
+   f. 把日志保存到 docs/plans/<slug>.logs/<routine>-<ts>.log
+3. 退出
+
+若任意步骤异常,转 failed,在 plan.md 正文记录 traceback,解锁退出。
+绝不调用 Ship gate 后的任何 skill。
+```
+
+具体 5 个 routine 的 prompt 在切换时再展开,不预先写,避免分叉漂移。
+
+## 11. 当前不启用的原因
+
+1. 这个 repo 单 feature 周期通常 < 1 天,B 方案足够
+2. cron 调度需要 `/schedule` 权限和环境,本地开发态没必要
+3. 还没建立"plan.md 是单一事实源"的习惯,直接上分布式状态机会乱
+4. 第一个 feature 还没用 B 方案验证过,谈优化太早
+
+**触发切换的明确信号**:有一个 feature 跑了 36 小时还没 ship,或者同时有 ≥3 个 feature 在不同阶段卡住。看到任一信号,回到 §9 切换。

--- a/src/deepagents_video_maker/agent.py
+++ b/src/deepagents_video_maker/agent.py
@@ -18,19 +18,51 @@ _SUBAGENT_SKILL_DIRS = {
 }
 
 
+def build_researcher_extra_tools() -> list[Any]:
+    """Return extra tools for the researcher subagent (e.g. web search).
+
+    Tavily is included when TAVILY_API_KEY is set in the environment.
+    Returns an empty list if no search key is configured.
+    """
+    tools: list[Any] = []
+    tavily_key = os.environ.get("TAVILY_API_KEY")
+    if tavily_key:
+        try:
+            from langchain_tavily import TavilySearch
+
+            tools.append(
+                TavilySearch(
+                    max_results=8,
+                    tavily_api_key=tavily_key,
+                    description=(
+                        "Search the web for up-to-date information. "
+                        "Use when source=websearch or when local knowledge is insufficient."
+                    ),
+                )
+            )
+        except ImportError:
+            pass  # langchain-tavily not installed; skip silently
+    return tools
+
+
 def build_subagents(project_root: str | Path | None = None) -> list[dict[str, Any]]:
     """Build DeepAgents subagent configs from native prompt files."""
 
     root = Path(project_root or Path.cwd()).resolve()
-    return [
-        {
+    researcher_extra_tools = build_researcher_extra_tools()
+
+    subagents: list[dict[str, Any]] = []
+    for name in SUBAGENT_NAMES:
+        spec: dict[str, Any] = {
             "name": name,
             "description": _subagent_description(name),
             "system_prompt": load_subagent_prompt(name),
             "skills": [str(root / _SUBAGENT_SKILL_DIRS[name])],
         }
-        for name in SUBAGENT_NAMES
-    ]
+        if name == "researcher" and researcher_extra_tools:
+            spec["tools"] = researcher_extra_tools
+        subagents.append(spec)
+    return subagents
 
 
 def build_native_tools() -> list[Callable[..., Any]]:

--- a/src/deepagents_video_maker/langchain_tools.py
+++ b/src/deepagents_video_maker/langchain_tools.py
@@ -195,6 +195,20 @@ def vm_start_script(output_dir: str) -> dict[str, Any]:
 
     state_path = Path(output_dir) / "state.yaml"
     state = load_state_yaml(state_path)
+    research = state.milestone("research")
+    if research.status.value != "completed":
+        # Return a structured error instead of raising — crashing the stream is not helpful.
+        return {
+            "error": (
+                f"Cannot start script milestone: research status is '{research.status.value}' "
+                "(must be 'completed'). "
+                "Call vm_ratify_research first and ensure it passes before calling vm_start_script."
+            ),
+            "research_status": research.status.value,
+            "retry_count": research.retry_count,
+            "max_retries": research.max_retries,
+            "state": to_jsonable(state),
+        }
     run = start_script_milestone(state)
     save_state_yaml(state, state_path)
     return {"state": to_jsonable(state), "run": to_jsonable(run)}
@@ -345,7 +359,8 @@ def _goal_from_inputs(
             raise ValueError("topic is required when structured inputs are provided")
         goal = parse_video_request(f"topic={topic}")
         if source is not None:
-            goal.source = source  # type: ignore[assignment]
+            # Normalize underscore variant (local_file) → hyphen (local-file)
+            goal.source = source.replace("_", "-")  # type: ignore[assignment]
         if local_file is not None:
             goal.local_file = local_file
         if notebook_url is not None:

--- a/src/deepagents_video_maker/ratify.py
+++ b/src/deepagents_video_maker/ratify.py
@@ -45,7 +45,8 @@ def ratify_research(
             {"heading_count": heading_count},
         )
     )
-    if source != "local-file":
+    # Accept both "local-file" and "local_file" spellings
+    if source not in ("local-file", "local_file"):
         checks.append(
             RatifyCheck(
                 "min_urls",

--- a/web-ui/.npmrc
+++ b/web-ui/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true

--- a/web-ui/next-env.d.ts
+++ b/web-ui/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/dev/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web-ui/next.config.ts
+++ b/web-ui/next.config.ts
@@ -1,8 +1,11 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
   turbopack: {
-    root: __dirname,
+    // Set root to workspace root so Turbopack can follow pnpm symlinks
+    // into node_modules/.pnpm which lives at workspace root, not web-ui/
+    root: path.resolve(__dirname, ".."),
   },
 };
 

--- a/web-ui/src/app/hooks/useChat.ts
+++ b/web-ui/src/app/hooks/useChat.ts
@@ -62,7 +62,7 @@ export function useChat({
           optimisticValues: (prev) => ({
             messages: [...(prev.messages ?? []), newMessage],
           }),
-          config: { ...(activeAssistant?.config ?? {}), recursion_limit: 100 },
+          config: { ...(activeAssistant?.config ?? {}), recursion_limit: 150 },
         }
       );
       // Update thread list immediately when sending a message
@@ -92,7 +92,10 @@ export function useChat({
       } else {
         stream.submit(
           { messages },
-          { config: activeAssistant?.config, interruptBefore: ["tools"] }
+          {
+            config: activeAssistant?.config,
+            interruptBefore: ["tools"],
+          }
         );
       }
     },
@@ -114,7 +117,7 @@ export function useChat({
       stream.submit(undefined, {
         config: {
           ...(activeAssistant?.config || {}),
-          recursion_limit: 100,
+          recursion_limit: 150,
         },
         ...(hasTaskToolCall
           ? { interruptAfter: ["tools"] }

--- a/web-ui/src/providers/ClientProvider.tsx
+++ b/web-ui/src/providers/ClientProvider.tsx
@@ -15,6 +15,43 @@ interface ClientProviderProps {
   apiKey: string;
 }
 
+// Stream modes supported by the langgraph-api server.
+// Newer @langchain/langgraph-sdk versions may request "tools" which older
+// server versions don't support — filter it out before the request goes out.
+const SUPPORTED_STREAM_MODES = new Set([
+  "values",
+  "messages",
+  "updates",
+  "events",
+  "debug",
+  "tasks",
+  "checkpoints",
+  "custom",
+  "messages-tuple",
+]);
+
+function filterStreamModes(_url: URL, init: RequestInit): RequestInit {
+  if (typeof init.body === "string") {
+    try {
+      const body = JSON.parse(init.body) as Record<string, unknown>;
+      if (Array.isArray(body.stream_mode)) {
+        const filtered = (body.stream_mode as string[]).filter((m) =>
+          SUPPORTED_STREAM_MODES.has(m)
+        );
+        if (filtered.length !== body.stream_mode.length) {
+          return {
+            ...init,
+            body: JSON.stringify({ ...body, stream_mode: filtered }),
+          };
+        }
+      }
+    } catch {
+      // Non-JSON body — pass through unchanged
+    }
+  }
+  return init;
+}
+
 export function ClientProvider({
   children,
   deploymentUrl,
@@ -27,6 +64,7 @@ export function ClientProvider({
         "Content-Type": "application/json",
         "X-Api-Key": apiKey,
       },
+      onRequest: filterStreamModes,
     });
   }, [deploymentUrl, apiKey]);
 


### PR DESCRIPTION
## Summary
- Add Tavily websearch to researcher subagent when `TAVILY_API_KEY` is set
- Support `anthropic:` provider prefix for ZhipuAI GLM via ChatAnthropic
- Gate `vm_start_script` on research completion, normalize source field
- Fix web-ui turbopack root, enable `streamSubgraphs`, increase `recursion_limit` to 150
- Add smoke invoke script, design docs, feature-pipeline skill skeleton

Closes AILS-28
Fixes AILS-26
Fixes AILS-27

🤖 Generated with [Claude Code](https://claude.com/claude-code)